### PR TITLE
Added proxy to vite config

### DIFF
--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -4,4 +4,15 @@ import react from '@vitejs/plugin-react'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/letters': {
+        target: "http://127.0.0.1:8080",
+        cors: true,
+        changeOrigin: true,
+        secure: false,
+        ws:true,
+      },
+    }
+  }
 })


### PR DESCRIPTION
Added the proxy to vite config file. Now when we make a request it will look something like this with fetch:
```js
fetch("/letters")
   .then(res => res.json())
   .then(data => {
      console.log(data)
   }
```
So no need for the full url which would be something like:
```js
fetch("http://localhost:8080/letters") //...
```
If you prefer using async/await, we can also do that. Depends on what you want to do with it is all!
